### PR TITLE
Add sprint event marker color, fix map layout, implement a map legend

### DIFF
--- a/assets/sass/style.scss
+++ b/assets/sass/style.scss
@@ -174,6 +174,15 @@ section.map {
   article {
     color: #fff;
   }
+  margin: 0 auto;
+  @media only screen and (min-width: 800px) {
+      min-width: 800px;
+      max-width: 1200px;
+  }
+
+  @media only screen and (max-width: 800px) {
+      width: auto;
+  }
 }
 
 
@@ -182,6 +191,7 @@ article {
 
   margin: 40px 0;
   font-size: 1.5em;
+  text-align: center;
   
   h2 {
     font-size: 2em;

--- a/themes/django20/static/js/events_map.js
+++ b/themes/django20/static/js/events_map.js
@@ -15,6 +15,7 @@ const map = L.map("map", {
 const categoryColors = {
 	conference: "#00f8a5", // green
 	meetup: "#005935", // accent green
+	sprint: "#B57EDC" // lavender
 };
 
 function getColorByCategory(category) {
@@ -107,3 +108,20 @@ L.Control.ResetView = L.Control.extend({
 L.control.resetView = (opts) => new L.Control.ResetView(opts);
 
 L.control.resetView({ position: "topleft" }).addTo(map);
+
+var legend = L.control({ position: 'bottomright' });
+
+legend.onAdd = function (map) {
+	var div = L.DomUtil.create('div', 'info legend');
+	var categories = Object.keys(categoryColors);
+	
+	categories.forEach(function(category) {
+		div.innerHTML +=
+		  '<i style="background:' + categoryColors[category] + '; width: 18px; height: 18px; display: inline-block; margin-right: 8px;"></i>' +
+		  category.charAt(0).toUpperCase() + category.slice(1) + '<br>';
+	  });
+	
+	  return div;
+	};
+	
+	legend.addTo(map);


### PR DESCRIPTION
## Description:

This PR introduces the following improvements:

- Adds a new marker color for the "sprint" event_category using lavender (#B57EDC)
- Fixes layout issues on the map page for better responsiveness and appearance
- Implements a legend control on the map to display the meaning of each event category color

<img width="1504" height="889" alt="spring_marker_color" src="https://github.com/user-attachments/assets/f53a96cf-6a6c-4931-9e5d-4f879bc00755" />
