### PR TITLE
Correct event marker date display affected by timezone (#6)

### DIFF
--- a/themes/django20/static/js/events_map.js
+++ b/themes/django20/static/js/events_map.js
@@ -45,7 +45,7 @@ function renderEvents(geojsonData) {
 		},
 		onEachFeature: (feature, layer) => {
 			const props = feature.properties;
-			const eventDate = new Date(props.date);
+			const eventDate = new Date(props.date + "T00:00:00Z");
 		  let eventDateEnd = null;
 			if (props.end_date) {
   			eventDateEnd = new Date(props.end_date);			  
@@ -56,6 +56,7 @@ function renderEvents(geojsonData) {
 			  year: "numeric",
 			  month: "long",
 			  day: "numeric",
+			  timeZone: "UTC",
 		  });		  
 			if (eventDateEnd) {
 			  formattedDate += "-" + eventDateEnd.toLocaleDateString("en-US", {
@@ -63,6 +64,7 @@ function renderEvents(geojsonData) {
 				  year: "numeric",
 				  month: "long",
 				  day: "numeric",
+				  timeZone: "UTC",
 			  });
 		  }
 


### PR DESCRIPTION
## Description:
This PR updates the date handling to directly create the event date using a fixed UTC midnight and display date using UTC timezone.

Resolves:
- https://github.com/django/birthday20/issues/63

### What’s included:
This basic fix addresses the current issue where event dates were shown one day earlier due to timezone parsing discrepancies.

It ensures all event dates are treated in UTC for consistent display on the map.

### Future Improvements
We could further enhance the date handling by incorporating the event's local start time (event_localtime) and explicit timezone offset (event_tz) when present.

This would allow displaying exact event start times localized to their respective timezones, improving accuracy and user comprehension.

### Testing
Verified in the browser how event marker dates appear to a user in a different local timezones (example: "America/New_York") before and after the code change, using timezone emulation. 
<img width="1030" height="103" alt="before_changes" src="https://github.com/user-attachments/assets/8e163c61-acef-4663-ae57-ae4d15174199" />
<img width="1030" height="103" alt="after_changes" src="https://github.com/user-attachments/assets/7ba402fe-3fdb-4f0d-9dcf-79d8abfd1e8d" />

Note: a hard refresh of the webpage may be necessary to see the changes.
