### PR TITLE
Fix the contrib app’s name to staticfiles.

### DIFF
--- a/content/timeline/2011-03-23-django-1.3.md
+++ b/content/timeline/2011-03-23-django-1.3.md
@@ -10,6 +10,6 @@ params:
 
 ---
 
-Django 1.3 is released: It introduced class-based views (CBVs) and `django.contrib.static`. Django no vendors unittest2 from Python 2.7 in order to maintain backwards compatibility with older Python versions. The `on_delete` option for foreign key fields is introduced.
+Django 1.3 is released: It introduced class-based views (CBVs) and `django.contrib.staticfiles`. Django no vendors unittest2 from Python 2.7 in order to maintain backwards compatibility with older Python versions. The `on_delete` option for foreign key fields is introduced.
 
 The `PROFANITIES_LIST` setting is introduced, rather than maintaining a list of naughty words inside the comments app.


### PR DESCRIPTION
This is because it was copied over from https://pypi.org/project/django-staticfiles/ which was incubated in the Pinax project.