### PR TITLE
Add map feature to cluster events by proximity using Leaflet MarkerCl…

### DIFF
--- a/assets/js/events_map.js
+++ b/assets/js/events_map.js
@@ -30,7 +30,7 @@ function renderEvents(geojsonData, singleEventGeojsonData) {
     return
   }
 
-  	// Marker cluster group 
+  	// Marker cluster group
   	var markers = L.markerClusterGroup({
 		maxClusterRadius: 15,  // Groups markers together if within 15 pixels of each other, adjustable as needed
 		showCoverageOnHover: false,
@@ -41,9 +41,9 @@ function renderEvents(geojsonData, singleEventGeojsonData) {
 		const zoomIncrement = 3; // Number of zoom levels to increase on cluster click, adjustable as needed
 		let nextZoom = currentZoom + zoomIncrement;
 		let maxZoom = map.getMaxZoom();
-	  
+
 		if (nextZoom > maxZoom) nextZoom = maxZoom;
-	  
+
 		if (nextZoom >= maxZoom - 7) {
 			// If zoom level is within 7 levels of max zoom, zoom directly to cluster bounds, adjustable as needed
 			a.layer.zoomToBounds({ padding: [20, 20] });
@@ -55,7 +55,7 @@ function renderEvents(geojsonData, singleEventGeojsonData) {
 	markers.on('clustermouseover', function(a) {
 		// Get all child markers of the cluster being hovered over
 		const clusteredMarkers = a.layer.getAllChildMarkers();
-	  
+
 		// Build the popup HTML string from all child features
 		let combinedInfo = '';
 		clusteredMarkers.forEach(marker => {
@@ -66,11 +66,11 @@ function renderEvents(geojsonData, singleEventGeojsonData) {
 			combinedInfo += `<b><span style="display:inline-block; width:12px; height:12px; background-color: ${popupCircleColor}; border-radius:50%; margin-right:6px; vertical-align:middle;"></span><span style="color:rgb(3, 98, 136);">${props.name}</span></b><br>`;
 		  }
 		});
-	  
+
 		// Bind a tooltip to the cluster marker with combined info and show it
 		a.layer.bindTooltip(combinedInfo || 'No event info available', { sticky: true, direction: 'auto' }).openTooltip();
 	  });
-	  
+
 	  markers.on('clustermouseout', function(a) {
 		a.layer.unbindTooltip();
 	  });

--- a/assets/js/events_map.js
+++ b/assets/js/events_map.js
@@ -26,12 +26,12 @@ function getColorByCategory(category) {
 let singleEventPopupLayer = null;
 
 function renderEvents(geojsonData, singleEventGeojsonData) {
-  if (!geojsonData) {
-    return
-  }
+	if (!geojsonData) {
+		return
+	}
 
-  	// Marker cluster group
-  	var markers = L.markerClusterGroup({
+	// Marker cluster group
+	var markers = L.markerClusterGroup({
 		maxClusterRadius: 15,  // Groups markers together if within 15 pixels of each other, adjustable as needed
 		showCoverageOnHover: false,
 		zoomToBoundsOnClick: false,
@@ -51,29 +51,33 @@ function renderEvents(geojsonData, singleEventGeojsonData) {
 			// Just zoom in incrementally if not near max zoom yet
 			map.flyTo(a.layer.getBounds().getCenter(), nextZoom, { duration: 0.5, animate: true });
 		}
-	  });
-	markers.on('clustermouseover', function(a) {
+	});
+	markers.on('clustermouseover', function (a) {
 		// Get all child markers of the cluster being hovered over
 		const clusteredMarkers = a.layer.getAllChildMarkers();
 
 		// Build the popup HTML string from all child features
-		let combinedInfo = '';
+		let combinedInfo = `
+		<svg xmlns="http://www.w3.org/2000/svg" color="gray" width="16" height="16" fill="currentColor" class="bi bi-info-square" viewBox="0 0 16 16">
+			<path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/>
+			<path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0"/>
+		</svg><br>`;
 		clusteredMarkers.forEach(marker => {
-		  if (marker.feature && marker.getPopup) {
-			const props = marker.feature.properties;
-			const popupCircleColor = getColorByCategory(props.event_category);
-			// Append a colored circle and marker name to the popup
-			combinedInfo += `<b><span style="display:inline-block; width:12px; height:12px; background-color: ${popupCircleColor}; border-radius:50%; margin-right:6px; vertical-align:middle;"></span><span style="color:rgb(3, 98, 136);">${props.name}</span></b><br>`;
-		  }
+			if (marker.feature && marker.getPopup) {
+				const props = marker.feature.properties;
+				const popupCircleColor = getColorByCategory(props.event_category);
+				// Append a colored circle and marker name to the popup
+				combinedInfo += `<b><span style="display:inline-block; width:12px; height:12px; background-color: ${popupCircleColor}; border-radius:50%; margin-right:6px; vertical-align:middle;"></span><span style="color:gray;font-style: italic;" >${props.name}</span></b><br>`;
+			}
 		});
 
 		// Bind a tooltip to the cluster marker with combined info and show it
 		a.layer.bindTooltip(combinedInfo || 'No event info available', { sticky: true, direction: 'auto' }).openTooltip();
-	  });
+	});
 
-	  markers.on('clustermouseout', function(a) {
+	markers.on('clustermouseout', function (a) {
 		a.layer.unbindTooltip();
-	  });
+	});
 
 	const geojsonLayer = L.geoJSON(geojsonData, {
 		pointToLayer: (feature, latlng) => {
@@ -96,27 +100,27 @@ function renderEvents(geojsonData, singleEventGeojsonData) {
 		onEachFeature: (feature, layer) => {
 			const props = feature.properties;
 			const eventDate = new Date(props.date + "T00:00:00Z");
-		  let eventDateEnd = null;
+			let eventDateEnd = null;
 			if (props.end_date) {
-  			eventDateEnd = new Date(props.end_date + "T00:00:00Z");
+				eventDateEnd = new Date(props.end_date + "T00:00:00Z");
 			}
 
-		  let formattedDate = eventDate.toLocaleDateString("en-US", {
-			  weekday: "long",
-			  year: "numeric",
-			  month: "long",
-			  day: "numeric",
-			  timeZone: "UTC",
-		  });
+			let formattedDate = eventDate.toLocaleDateString("en-US", {
+				weekday: "long",
+				year: "numeric",
+				month: "long",
+				day: "numeric",
+				timeZone: "UTC",
+			});
 			if (eventDateEnd) {
-			  formattedDate += "-" + eventDateEnd.toLocaleDateString("en-US", {
-				  weekday: "long",
-				  year: "numeric",
-				  month: "long",
-				  day: "numeric",
-				  timeZone: "UTC",
-			  });
-		  }
+				formattedDate += "-" + eventDateEnd.toLocaleDateString("en-US", {
+					weekday: "long",
+					year: "numeric",
+					month: "long",
+					day: "numeric",
+					timeZone: "UTC",
+				});
+			}
 
 			layer.bindPopup(`
                 <a href="${props.website}" target="_blank"><b>${props.name}</b><br></a>
@@ -150,7 +154,7 @@ function renderEvents(geojsonData, singleEventGeojsonData) {
 
 let eventDetailData = null;
 if (singleEventData) {
-    eventDetailData = eventsData.features.find(f =>
+	eventDetailData = eventsData.features.find(f =>
 		(f.properties.name && singleEventData.title && f.properties.name === singleEventData.title) &&
 		(f.properties.date && singleEventData.event_date && f.properties.date === singleEventData.event_date)
 	);
@@ -175,12 +179,12 @@ L.Control.ResetView = L.Control.extend({
 		L.DomEvent.preventDefault(e);
 
 		// If you have a single event layer with bounds
-        if (eventDetailData && eventDetailData.geometry) {
-            this._map.fitBounds(L.geoJSON({ type: "FeatureCollection", features: [eventDetailData] }).getBounds().pad(0.2));
+		if (eventDetailData && eventDetailData.geometry) {
+			this._map.fitBounds(L.geoJSON({ type: "FeatureCollection", features: [eventDetailData] }).getBounds().pad(0.2));
 			singleEventPopupLayer.openPopup();
-        }
+		}
 		else {
-        	// Else, fallback to default view, the world view
+			// Else, fallback to default view, the world view
 			this._map.setView([30, 0], 2);
 		}
 	},
@@ -196,13 +200,13 @@ legend.onAdd = function (map) {
 	var div = L.DomUtil.create('div', 'info legend');
 	var categories = Object.keys(categoryColors);
 
-	categories.forEach(function(category) {
+	categories.forEach(function (category) {
 		div.innerHTML +=
-		  '<i style="background:' + categoryColors[category] + '; width: 18px; height: 18px; display: inline-block; margin-right: 8px;"></i>' +
-		  category.charAt(0).toUpperCase() + category.slice(1) + '<br>';
-	  });
+			'<i style="background:' + categoryColors[category] + '; width: 18px; height: 18px; display: inline-block; margin-right: 8px;"></i>' +
+			category.charAt(0).toUpperCase() + category.slice(1) + '<br>';
+	});
 
-	  return div;
+	return div;
 };
 
 legend.addTo(map);

--- a/assets/js/events_map.js
+++ b/assets/js/events_map.js
@@ -29,12 +29,57 @@ function renderEvents(geojsonData, singleEventGeojsonData) {
   if (!geojsonData) {
     return
   }
+
+  	// Marker cluster group 
+  	var markers = L.markerClusterGroup({
+		maxClusterRadius: 15,  // Groups markers together if within 15 pixels of each other, adjustable as needed
+		showCoverageOnHover: false,
+		zoomToBoundsOnClick: false,
+	});
+	markers.on('clusterclick', function (a) {
+		let currentZoom = map.getZoom();
+		const zoomIncrement = 3; // Number of zoom levels to increase on cluster click, adjustable as needed
+		let nextZoom = currentZoom + zoomIncrement;
+		let maxZoom = map.getMaxZoom();
+	  
+		if (nextZoom > maxZoom) nextZoom = maxZoom;
+	  
+		if (nextZoom >= maxZoom - 7) {
+			// If zoom level is within 7 levels of max zoom, zoom directly to cluster bounds, adjustable as needed
+			a.layer.zoomToBounds({ padding: [20, 20] });
+		} else {
+			// Just zoom in incrementally if not near max zoom yet
+			map.flyTo(a.layer.getBounds().getCenter(), nextZoom, { duration: 0.5, animate: true });
+		}
+	  });
+	markers.on('clustermouseover', function(a) {
+		// Get all child markers of the cluster being hovered over
+		const clusteredMarkers = a.layer.getAllChildMarkers();
+	  
+		// Build the popup HTML string from all child features
+		let combinedInfo = '';
+		clusteredMarkers.forEach(marker => {
+		  if (marker.feature && marker.getPopup) {
+			const props = marker.feature.properties;
+			const popupCircleColor = getColorByCategory(props.event_category);
+			// Append a colored circle and marker name to the popup
+			combinedInfo += `<b><span style="display:inline-block; width:12px; height:12px; background-color: ${popupCircleColor}; border-radius:50%; margin-right:6px; vertical-align:middle;"></span><span style="color:rgb(3, 98, 136);">${props.name}</span></b><br>`;
+		  }
+		});
+	  
+		// Bind a tooltip to the cluster marker with combined info and show it
+		a.layer.bindTooltip(combinedInfo || 'No event info available', { sticky: true, direction: 'auto' }).openTooltip();
+	  });
+	  
+	  markers.on('clustermouseout', function(a) {
+		a.layer.unbindTooltip();
+	  });
+
 	const geojsonLayer = L.geoJSON(geojsonData, {
 		pointToLayer: (feature, latlng) => {
 			const category = feature.properties.event_category;
 			const color = getColorByCategory(category);
-
-			return L.circleMarker(latlng, {
+			const marker = L.circleMarker(latlng, {
 				radius: 8,
 				fillColor: color,
 				color: "#000",
@@ -42,6 +87,11 @@ function renderEvents(geojsonData, singleEventGeojsonData) {
 				opacity: 1,
 				fillOpacity: 0.8,
 			});
+
+			// Add circle marker to the cluster group
+			markers.addLayer(marker);
+
+			return marker;
 		},
 		onEachFeature: (feature, layer) => {
 			const props = feature.properties;
@@ -79,7 +129,10 @@ function renderEvents(geojsonData, singleEventGeojsonData) {
 				singleEventPopupLayer = layer;
 			}
 		},
-	}).addTo(map);
+	})
+
+	// Add the cluster group to the map instead of geojsonLayer
+	map.addLayer(markers);
 
 	// Auto-fit only if there are features
 	if (geojsonData.features.length > 0 && !singleEventGeojsonData) {

--- a/themes/django20/layouts/partials/events_map.html
+++ b/themes/django20/layouts/partials/events_map.html
@@ -1,6 +1,9 @@
 <!-- Leaflet CSS file -->
 <link rel="stylesheet" type="text/css" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
 integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+<!-- Leaflet Marker Cluster CSS files -->
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.4.1/MarkerCluster.css" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.5.0/MarkerCluster.Default.min.css" />
 
 <!-- Map -->
 {{ $events := .events }}
@@ -42,6 +45,8 @@ integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" /
 <!-- Leaflet JS file -->
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
 integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+<!-- Leaflet Marker Cluster JS file -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.markercluster/1.4.1/leaflet.markercluster.js"></script>
 <!-- project JS file -->
 {{ with resources.Get "js/events_map.js" }}
   {{ with . | fingerprint "sha256" }}


### PR DESCRIPTION
## Description:
This PR introduces the Leaflet MarkerClusterGroup plugin to enhance map usability by clustering markers based on proximity, as discussed in issue #75.

Resolves:
- https://github.com/django/birthday20/issues/75

### Key features and configurable parameters include:
- Configured maxClusterRadius to control clustering distance flexibility. It controls how close markers must be to each other to form clusters, adjustable to suit data density.
- Disabled some of the Leaflet.markercluster default behaviors, "showCoverageOnHover" and "zoomToBoundsOnClick", to implement the customized cluster hover tooltips and zoom behavior desired.
- Added custom zoom increment and direct zoom threshold to improve cluster click behavior: 
  1. zoomIncrement = 3: Defines how many zoom levels the map increments when a cluster is clicked. This value is adjustable to control zoom behavior flexibility.
  2. Zoom threshold of 7 levels from max zoom: When the map zoom level is within 7 levels of maximum zoom, the map zooms directly to the cluster bounds instead of incrementally. This threshold is adjustable to optimize user experience near max zoom.
- Customized cluster hover tooltips to show event categories with color coding

These enhancements improve map usability and prevents markers at the same location from overlapping, showing all points clearly by clustering them.

### Screenshots

**Map on Homepage:**
<img width="1542" height="818" alt="Screenshot from 2025-09-06 16-46-50" src="https://github.com/user-attachments/assets/afa8138d-0f22-4fe8-8e53-370ee31ca8c3" />
<img width="1542" height="818" alt="Screenshot from 2025-09-06 16-47-05" src="https://github.com/user-attachments/assets/8b3c59e8-ecf8-468e-a5fd-c1db7072bf3b" />
<img width="1542" height="818" alt="Screenshot from 2025-09-06 16-47-35" src="https://github.com/user-attachments/assets/684236cd-98e1-4049-9140-ac9fb5b8264f" />
