### PR TITLE
Add date ranges to events that previously had none. For events withou…

### DIFF
--- a/content/events/copenhagen.md
+++ b/content/events/copenhagen.md
@@ -8,6 +8,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-10-10"
+  event_date_end: ""
   event_localtime: "15:00"
   event_host: "Django Denmark"
   event_tz: "+02:00"

--- a/content/events/django-india-chennai-meetup.md
+++ b/content/events/django-india-chennai-meetup.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-04-26"
+  event_date_end: ""
   event_host: "Django India"
   event_localtime: ""
   event_tz: ""

--- a/content/events/django-india-surat-meetup.md
+++ b/content/events/django-india-surat-meetup.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-01-18"
+  event_date_end: ""
   event_host: "Django India"
   event_localtime: ""
   event_tz: ""

--- a/content/events/django-india-x-gdg-lucknow-meetup.md
+++ b/content/events/django-india-x-gdg-lucknow-meetup.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-03-29"
+  event_date_end: ""
   event_host: "Django India"
   event_localtime: ""
   event_tz: ""

--- a/content/events/django-india-x-kolkata-foss-meetup.md
+++ b/content/events/django-india-x-kolkata-foss-meetup.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-02-08"
+  event_date_end: ""
   event_host: "Django India"
   event_localtime: ""
   event_tz: ""

--- a/content/events/django-london-meetup-may.md
+++ b/content/events/django-london-meetup-may.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-05-13"
+  event_date_end: ""
   event_host: "Django London Meetup"
   event_localtime: ""
   event_tz: ""

--- a/content/events/django-london.md
+++ b/content/events/django-london.md
@@ -8,6 +8,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-07-08"
+  event_date_end: ""
   event_localtime: "18:15"
   event_tz: "+01:00"
   event_host: "Django London"

--- a/content/events/django-meetup-vol-66-decoupling-the-monolith-queue.md
+++ b/content/events/django-meetup-vol-66-decoupling-the-monolith-queue.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-05-20"
+  event_date_end: ""
   event_host: "Django Meetup Cologne"
   event_localtime: ""
   event_tz: ""

--- a/content/events/django-vienna-062025.md
+++ b/content/events/django-vienna-062025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-06-10"
+  event_date_end: ""
   event_host: "Django Friends"
   event_localtime: ""
   event_tz: ""

--- a/content/events/django-vienna-092025.md
+++ b/content/events/django-vienna-092025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-09-09"
+  event_date_end: ""
   event_host: "Django Friends"
   event_localtime: ""
   event_tz: ""

--- a/content/events/django-vienna-112025.md
+++ b/content/events/django-vienna-112025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-11-11"
+  event_date_end: ""
   event_host: "Django Friends"
   event_localtime: ""
   event_tz: ""

--- a/content/events/djangocon-africa-2025.md
+++ b/content/events/djangocon-africa-2025.md
@@ -11,17 +11,18 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-08-11"
+  event_date_end: "2025-08-15"
   event_host: "DjangoCon Africa"
   event_localtime: ""
   event_tz: ""
   event_languages: ""
   event_url: "https://2025.djangocon.africa/"
-  latitude: -3.387004436658432
-  longitude: 36.684249993336
+  latitude: -3.3962627350913963
+  longitude: 36.70518526087581
   country: "Tanzania"
   city: "Arusha"
-  venue_name: ""
-  venue_address: "The specific location within Arusha, Tanzania hasn't been officially announced yet."
+  venue_name: "Life Fitness Hall"
+  venue_address: "Life Fitness Hall, Njiro Road, Arusha, Tanzania"
   social_media:
 ---
 

--- a/content/events/djangocon-us-2025.md
+++ b/content/events/djangocon-us-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-09-08"
+  event_date_end: "2025-09-12"
   event_host: "DjangoCon US"
   event_localtime: ""
   event_tz: ""

--- a/content/events/europython-2025.md
+++ b/content/events/europython-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-07-14"
+  event_date_end: "2025-07-20"
   event_host: "EuroPython"
   event_localtime: ""
   event_tz: ""

--- a/content/events/happy-birthday-python-pescara.md
+++ b/content/events/happy-birthday-python-pescara.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-05-20"
+  event_date_end: ""
   event_host: "Python Pescara"
   event_localtime: ""
   event_tz: ""

--- a/content/events/i-meetup-pydata-pa.md
+++ b/content/events/i-meetup-pydata-pa.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-09-06"
+  event_date_end: ""
   event_host: "PyData Pará"
   event_localtime: ""
   event_tz: ""

--- a/content/events/integrating-ai-with-django-workshop.md
+++ b/content/events/integrating-ai-with-django-workshop.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-04-24"
+  event_date_end: ""
   event_host: "Django Cameroon"
   event_localtime: ""
   event_tz: ""

--- a/content/events/piterpy-2025.md
+++ b/content/events/piterpy-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "hybrid"
   event_category: "conference"
   event_date: "2025-05-16"
+  event_date_end: "2025-05-17"
   event_host: "PiterPy"
   event_localtime: ""
   event_tz: ""

--- a/content/events/pybay-2025.md
+++ b/content/events/pybay-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-10-18"
+  event_date_end: ""
   event_host: "PyBay"
   event_localtime: ""
   event_tz: ""

--- a/content/events/pycon-colombia-2025.md
+++ b/content/events/pycon-colombia-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-07-04"
+  event_date_end: "2025-07-06"
   event_host: "PyCon Colombia"
   event_localtime: ""
   event_tz: ""

--- a/content/events/pycon-estonia-2025.md
+++ b/content/events/pycon-estonia-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-10-02"
+  event_date_end: "2025-10-03"
   event_host: "PyCon Estonia"
   event_localtime: ""
   event_tz: ""

--- a/content/events/pycon-greece-2025.md
+++ b/content/events/pycon-greece-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-08-29"
+  event_date_end: "2025-08-30"
   event_host: "PyCon Greece"
   event_localtime: ""
   event_tz: ""

--- a/content/events/pycon-italia-2025.md
+++ b/content/events/pycon-italia-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-05-28"
+  event_date_end: "2025-05-31"
   event_host: "PyCon Italia"
   event_localtime: ""
   event_tz: ""

--- a/content/events/pycon-jp-2025.md
+++ b/content/events/pycon-jp-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-09-26"
+  event_date_end: "2025-09-27"
   event_host: "PyCon JP"
   event_localtime: ""
   event_tz: ""

--- a/content/events/pycon-russia-2025.md
+++ b/content/events/pycon-russia-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-07-25"
+  event_date_end: "2025-07-26"
   event_host: "PyCon Russia"
   event_localtime: ""
   event_tz: ""

--- a/content/events/pycon-sweden-2025.md
+++ b/content/events/pycon-sweden-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-10-30"
+  event_date_end: "2025-10-31"
   event_host: "PyCon Sweden"
   event_localtime: ""
   event_tz: ""

--- a/content/events/pycon-thailand-2025.md
+++ b/content/events/pycon-thailand-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-10-17"
+  event_date_end: "2025-10-18"
   event_host: "PyCon Thailand"
   event_localtime: ""
   event_tz: ""
@@ -20,7 +21,7 @@ params:
   longitude: 100.60218598854522
   country: "Thailand"
   city: "10260"
-  venue_name: ""
+  venue_name: "Avani Sukhumvit Bangkok Hotel"
   venue_address: "2089 Sukhumvit Rd, Prakanong Nua Watthana, Bangkok 10260, Thailand"
   social_media:
 ---

--- a/content/events/pycon-uganda-2025.md
+++ b/content/events/pycon-uganda-2025.md
@@ -10,18 +10,19 @@ draft: false
 params:
   event_type: "in_person"
   event_category: "conference"
-  event_date: "2025-08-06"
+  event_date: "2025-08-07"
+  event_date_end: "2025-08-09"
   event_host: "PyCon Uganda"
   event_localtime: ""
   event_tz: ""
   event_languages: ""
   event_url: "https://ug.pycon.org/"
-  latitude: 0.31749216212313847
-  longitude: 32.58401552572154
+  latitude: 0.33391140953919884
+  longitude: 32.56802819711846
   country: "Uganda"
   city: "Kampala"
-  venue_name: ""
-  venue_address: "Kampala, Uganda - (The Venue will be announced soon.)"
+  venue_name: "Ivory Tower, Makerere University"
+  venue_address: "8HM9+F27, University Rd, Kampala, Uganda"
   social_media:
 ---
 

--- a/content/events/pycon-us-2025.md
+++ b/content/events/pycon-us-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-05-14"
+  event_date_end: "2025-05-22"
   event_host: "PyCon US"
   event_localtime: ""
   event_tz: ""

--- a/content/events/pyconfr-2025.md
+++ b/content/events/pyconfr-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-10-30"
+  event_date_end: "2025-11-02"
   event_host: "PyConFR"
   event_localtime: ""
   event_tz: ""

--- a/content/events/pyday-valparaiso-2025.md
+++ b/content/events/pyday-valparaiso-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-06-13"
+  event_date_end: ""
   event_host: "PyDay Chile"
   event_localtime: ""
   event_tz: ""

--- a/content/events/pyho-2025.md
+++ b/content/events/pyho-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-10-24"
+  event_date_end: "2025-10-25"
   event_host: "PyHo"
   event_localtime: ""
   event_tz: ""

--- a/content/events/python-brasil-2025.md
+++ b/content/events/python-brasil-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-10-21"
+  event_date_end: "2025-10-27"
   event_host: "Python Brasil"
   event_localtime: ""
   event_tz: ""

--- a/content/events/swiss-python-summit-2025.md
+++ b/content/events/swiss-python-summit-2025.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "conference"
   event_date: "2025-10-16"
+  event_date_end: "2025-10-17"
   event_host: "Swiss Python Summit"
   event_localtime: ""
   event_tz: ""

--- a/content/events/tokyo-python-reboot.md
+++ b/content/events/tokyo-python-reboot.md
@@ -11,6 +11,7 @@ params:
   event_type: "in_person"
   event_category: "meetup"
   event_date: "2025-05-22"
+  event_date_end: ""
   event_host: "Tokyo Python"
   event_localtime: ""
   event_tz: ""


### PR DESCRIPTION
## Description:
This PR updates existing events to include date ranges where they were missing, as described in issue #35. Events that already had date ranges were updated accordingly. For events without an end date, the field `event_date_end` was added with an empty string to maintain consistent data structure.

Resolves: https://github.com/django/birthday20/issues/35

### What’s included:
- Updates date ranges on existing events
- Adds `event_date_end: ""` for events that occur on a single day

This improves event data completeness and consistency.