### PR TITLE
Add embedded map on event detail page with focused event marker and opened popup

### DIFF
--- a/themes/django20/layouts/events/single.html
+++ b/themes/django20/layouts/events/single.html
@@ -21,6 +21,12 @@
 {{ end }}
 
 {{ define "main" }}
+  {{ $events := (where (.Site.GetPage "/events").Pages.ByDate "published" "!=" "false") }}
+
+  <section class="map" id="event-map">
+    <div class="container">
+    {{ partial "events_map.html" (dict "events" $events "sigleEvent" .Params "context" .) }}
+  </section>
   <section>
     <div class="container container-main {{ .Params.cssClassSuffix }}">
       <article class="{{ .Params.cssClassSuffix }}">

--- a/themes/django20/layouts/partials/events_map.html
+++ b/themes/django20/layouts/partials/events_map.html
@@ -6,6 +6,7 @@ integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" /
 {{ $events := .events }}
 <div id="map" aria-label="Django 20th Anniversary Event Locations"></div>
 <script>
+    const singleEventData = {{ .sigleEvent | default "null" }};
     const eventsData = {
         "type": "FeatureCollection",
         "features": [


### PR DESCRIPTION
## Description:
This PR partially fixes issue #19 (Nice to have: Embedded map on event details page) by implementing the zoomed-in map on event detail pages. The map now zooms and centers on the current event, highlights it with the popup open initially, but also shows all other events in the background for context.

Partially Resolves:
- https://github.com/django/birthday20/issues/19

### What’s included:
- Renders the map zoomed and centered on the current event on detail pages.
- Renders all other events with normal markers visible.
- Highlights the focused event marker by opening its popup.
- Integrates a reset view button which zooms back to the focused event marker.
- Retains the focused event zoom and popup state on page refresh for a consistent user experience.
- Allows users to pan and zoom out to explore other events after initial focus.

### Remaining work

- The only remaining bit is to prevent external links or immediate navigation when clicking events, as currently clicking an event still leaves the site.

This PR is a step toward having dedicated event detail pages within the site, reducing external navigation on event clicks.

### Screenshots
**Map on Event Detail Page (Two Views):**
<img width="1532" height="1033" alt="Screenshot from 2025-09-07 01-14-51" src="https://github.com/user-attachments/assets/039ac904-4d47-4041-949f-8702b48b4ae5" />
<img width="1532" height="1033" alt="Screenshot from 2025-09-07 01-13-13" src="https://github.com/user-attachments/assets/3fa05f9f-a779-4dce-be67-2d5bed4e82fe" />
