### PR TITLE
Added privacy-friendly embed shortcode with consent and placeholderFeature/privacy modal

### DIFF
--- a/assets/css/privacy-embed.css
+++ b/assets/css/privacy-embed.css
@@ -1,0 +1,38 @@
+.privacy-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;      
+  max-width: 560px;         
+  margin: 1em auto;
+  position: relative; 
+}
+
+.privacy-placeholder img {
+  width: 100%;
+  height: auto;
+  display: block;
+  margin-bottom: 1em;
+}
+
+.privacy-placeholder p {
+  font-size: 25px;
+  margin: 1em 0;  
+}
+
+.privacy-placeholder button {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 0.7em 1em;
+  background: rgb(255, 0, 0);
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.privacy-placeholder button:hover {
+  background: rgb(223, 30, 30);
+}

--- a/assets/js/privacy-embed.js
+++ b/assets/js/privacy-embed.js
@@ -1,0 +1,66 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const embeds = document.querySelectorAll(".privacy-embed");
+
+  // consent check
+
+  embeds.forEach(embed => {
+    const provider = embed.dataset.provider || "youtube";
+    const videoId = embed.dataset.id;
+    const consentKey = "consent-" + provider + "-" + videoId;
+
+  // If consent is already given → directly load the embed
+
+    if (localStorage.getItem(consentKey) === "true") {
+      loadEmbed(embed, provider, videoId, false);
+    } else {
+      showPlaceholder(embed, provider, videoId, consentKey);
+    }
+  });
+
+  // It displays a placeholder before loading the actual embed
+
+  function showPlaceholder(embed, provider, videoId, consentKey) {
+    const thumbnail = embed.dataset.thumbnail 
+      || (provider === "youtube" 
+          ? `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`
+          : "https://via.placeholder.com/480x270?text=Preview");
+
+    embed.innerHTML = `
+      <div class="privacy-placeholder">
+        <img src="${thumbnail}" alt="${provider} preview" />
+        <p>
+          By playing this ${provider} embed you accept
+          <a href="https://policies.google.com/privacy" target="_blank">privacy policy</a>.
+        </p>
+        <button class="privacy-accept">Accept & Play</button>
+      </div>
+    `;
+
+    embed.querySelector(".privacy-accept").addEventListener("click", () => {
+      localStorage.setItem(consentKey, "true");
+      loadEmbed(embed, provider, videoId, true);
+    });
+  }
+
+  // Actual iframe is loaded 
+  function loadEmbed(embed, provider, videoId, autoplay) {
+    let src = "";
+
+    if (provider === "youtube") {
+      src = `https://www.youtube-nocookie.com/embed/${videoId}`;
+      if (autoplay) {
+        src += `?autoplay=1`;
+      }
+    }
+   
+
+    embed.outerHTML = `
+      <iframe 
+        src="${src}" 
+        frameborder="0" 
+        allowfullscreen
+        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture">
+      </iframe>
+    `;
+  }
+});

--- a/content/timeline/2015-07-13-10th-birthday.md
+++ b/content/timeline/2015-07-13-10th-birthday.md
@@ -12,4 +12,8 @@ params:
 Django has its first big birthday celebration. [A blog post](https://www.djangoproject.com/weblog/2015/jul/13/happy-10th-birthday-django/
 ) is written and a Django Birthday conference is held in the US. Also this series of video greetings is sent from community all-over the world:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/ycKC3JMEk8U?si=aA1yutBYSxLLZgnr" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+{{< privacy-embed 
+      provider="youtube" 
+      id="ycKC3JMEk8U" 
+      thumbnail="https://img.youtube.com/vi/ycKC3JMEk8U/maxresdefault.jpg" 
+>}}

--- a/themes/django20/layouts/_default/baseof.html
+++ b/themes/django20/layouts/_default/baseof.html
@@ -20,6 +20,7 @@
   <link rel="stylesheet" href="{{ $style.Permalink }}" />
 
   <link href="/css/zoom-vanilla.min.css" rel="stylesheet">
+  <link href="/css/privacy-embed.css" rel="stylesheet">
 
   {{ template "_internal/twitter_cards.html" . }}
   {{ template "_internal/opengraph.html" . }}
@@ -84,6 +85,7 @@
   {{ end }}
 {{ end }}
 
+<script src="/js/privacy-embed.js"></script>
 </body>
 
 </html>

--- a/themes/django20/layouts/shortcodes/privacy-embed.html
+++ b/themes/django20/layouts/shortcodes/privacy-embed.html
@@ -1,0 +1,5 @@
+<div class="privacy-embed"
+     data-provider="{{ .Get "provider" }}"  
+     data-id="{{ .Get "id" }}"
+     {{ with .Get "thumbnail" }} data-thumbnail="{{ . }}"{{ end }}>
+</div>


### PR DESCRIPTION
### Summary
This PR introduces a new privacy-friendly embed system for YouTube. It includes:

- A Hugo shortcode: `privacy-embed.html` (located in themes/django20/layouts/shortcodes/)
- JavaScript functionality (`privacy-embed.js`) for consent management and iframe loading
- CSS styling (`privacy-embed.css`) for placeholder and consent button
- Integration of JS and CSS into `baseof.html` to ensure the embed works across all pages

### Features
1. **Consent-based loading:**  
   Users must click "Accept & Play" to load the actual video or track, protecting privacy by avoiding automatic third-party requests.
   
2. **Thumbnail/Placeholder:**  
   - YouTube: automatic high-quality thumbnail if none provided  
   - Other providers: fallback placeholder image
   - Optional custom thumbnail via shortcode parameter

3. **Provider Support:**  
   - YouTube (default)

### Usage Example
Markdown example for embedding a video:

<img width="500" height="250" alt="Screenshot 2025-09-27 162621" src="https://github.com/user-attachments/assets/71273eaf-780c-452a-a14d-3855d57e6f4c" />