### PR TITLE
Create django-girls-bogota.md

### DIFF
--- a/content/events/django-girls-bogota.md
+++ b/content/events/django-girls-bogota.md
@@ -1,0 +1,130 @@
+---
+# Django Girls Bogotá Workshop
+title: "Django Girls Bogotá Workshop 2025"
+# Workshop for women to learn Django and build their first website
+description: "We want to inspire more women to fall in love with programming! Free intensive workshop to build your website from scratch."
+# Publication date (today's date)
+date: "2025-09-23"
+# Change this to "false" so the event will appear
+draft: false
+
+params:
+  # Possible values: "in_person", "online", "hybrid" or "radio"
+  event_type: "in_person"
+  # Possible values: "meetup" or "conference"
+  event_category: "meetup"
+  # YYYY-MM-DD
+  event_date: "2025-11-01"
+  # Leave empty if single-day event.
+  event_date_end: ""
+  # Local time of event: "TBD" (since it's all day)
+  event_localtime: ""
+  # Timezone UTC offset of Colombia
+  event_tz: "-05:00"
+  # Your community's name
+  event_host: "Django Girls Colombia and Python Colombia"
+  # Languages expected to be spoken
+  event_languages: "Spanish"
+  # Registration and event details URL
+  event_url: "https://djangogirls.org/es/bogota/"
+  # Bogotá coordinates (approximate)
+  latitude: 4.7110
+  longitude: -74.0721
+  # Country and city
+  country: "Colombia"
+  city: "Bogotá"
+  # Venue information
+  venue_name: "Universidad de Bogotá Jorge Tadeo Lozano"
+  # Exact venue address
+  venue_address: "Carrera 4 # 22-61, Bogotá, Colombia"
+  # Social media (add if available)
+  social_media:
+    # twitter: "..."
+    # instagram: "..."
+---
+
+# Django Girls Bogotá Workshop 2025 🚀
+
+We want to inspire more women to fall in love with programming! Django Girls Colombia and Python Colombia are organizing a workshop where you can **build your own website from scratch in one day**.
+
+---
+
+## 🎯 What will you learn?
+
+- **Build your first web application** using Django framework
+- **Master professional tools** that developers use daily
+- **Create a complete website** from zero to deployment
+- **Join a supportive community** of women in tech
+
+---
+
+## 📅 Event Details
+
+| Detail | Information |
+|--------|-------------|
+| **Date** | November 1st, 2025 (Saturday) |
+| **Location** | Universidad de Bogotá Jorge Tadeo Lozano |
+| **Duration** | Full-day intensive workshop (8+ hours) |
+| **Cost** | **100% FREE** 🎉 |
+| **Capacity** | Limited to 70 participants |
+| **Language** | Spanish |
+
+---
+
+## 👩‍💻 Who should attend?
+
+✅ **Perfect for you if:**
+- You are a woman interested in technology
+- You want to learn web development
+- You're new to programming (no experience needed!)
+- You're ready to learn quickly and have fun
+
+❌ **Not suitable if:**
+- You already have extensive Django experience
+- You can't commit to the full day
+
+---
+
+## 🚀 How to register
+
+**⚠️⏰ IMPORTANT: Registration closes October 12th, 2025! ⏰⚠️**
+
+Ready to start your programming journey? 
+
+👉 **[REGISTER NOW at djangogirls.org](https://djangogirls.org/es/bogota/)** 👈
+
+*Spots fill up quickly! Register as soon as possible to secure your place.*
+
+---
+
+## 💪 Why Django Girls?
+
+Django Girls is a **global movement** that has already inspired thousands of women worldwide to start their journey in technology. We believe the IT industry benefits greatly from having more women in tech roles.
+
+**Our mission:** Give you the tools, knowledge, and confidence to become one of us – **Women Programmers!**
+
+---
+
+## 🤝 Community & Support
+
+This workshop is brought to you by:
+- **Django Girls Colombia** 🇨🇴
+- **Python Colombia** 🐍
+
+Join a **supportive community** where you can continue learning and growing even after the workshop ends.
+
+---
+
+## 📋 Code of Conduct
+
+We are committed to providing a **safe, inclusive, and welcoming environment** for all participants, regardless of background or experience level.
+
+All attendees, speakers, sponsors, and volunteers must follow our code of conduct throughout the event.
+
+📖 **[Read the full Django Girls Code of Conduct](https://djangogirls.org/coc/)**
+
+---
+
+**Questions?** Contact the organizers through the [Django Girls Bogotá website](https://djangogirls.org/es/bogota/).
+
+*Let's code together! 💻✨*

--- a/content/events/django-girls-bogota.md
+++ b/content/events/django-girls-bogota.md
@@ -89,7 +89,7 @@ We want to inspire more women to fall in love with programming! Django Girls Col
 
 **⚠️⏰ IMPORTANT: Registration closes October 12th, 2025! ⏰⚠️**
 
-Ready to start your programming journey? 
+Ready to start your programming journey?
 
 👉 **[REGISTER NOW at djangogirls.org](https://djangogirls.org/es/bogota/)** 👈
 


### PR DESCRIPTION
Add Django Girls Bogotá Workshop 2025 event for Django's 20th birthday celebration.

This free, full-day workshop organized by Django Girls Colombia and Python Colombia will take place on November 1st, 2025 at Universidad de Bogotá Jorge Tadeo Lozano.

Event highlights:
- Target audience: Women interested in learning web development
- Capacity: 70 participants
- Focus: Building first web application using Django
- Registration closes: October 12th, 2025
- Event URL: https://djangogirls.org/es/bogota/

This event aligns with Django's birthday celebration by promoting diversity and inclusion in the Django community, specifically encouraging more women to join the tech industry through hands-on learning.