### PR TITLE
pyday-cumple-django-bogota

### DIFF
--- a/content/events/pyday-cumple-django-bogota.md
+++ b/content/events/pyday-cumple-django-bogota.md
@@ -89,8 +89,8 @@ This event is perfect for:
 
 ## 📍 Venue
 
-**Universidad Jorge Tadeo Lozano - Sala Oval**  
-Carrera 4 # 22-61  
+**Universidad Jorge Tadeo Lozano - Sala Oval**
+Carrera 4 # 22-61
 Santa Fé, Bogotá, Colombia
 
 A central location in Bogotá, easily accessible by public transportation.


### PR DESCRIPTION
Add PyDay and Django Birthday celebration event in Bogotá.

This special event organized by PyLadies Colombia combines PyDay with Django's 20th birthday on October 31st, 2025.

Event highlights:
- Date: October 31st, 2025 (PyDay + Django Birthday)
- Time: 1:00 PM - 6:00 PM COT
- Venue: Universidad Jorge Tadeo Lozano - Sala Oval
- Organizer: PyLadies Colombia
- Features talks, networking, and themed celebrations

This event celebrates Django's milestone anniversary while promoting diversity and inclusion in the Python community through PyLadies Colombia's leadership.