### PR TITLE
Added event contribution instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,6 @@ uv run hugo server
 ```
 
 🎉 Add Your Event to Django's 20th Birthday!
----------------------
+--------------------------------------------
 
 Please follow the instructions in [`content/add-event.md`](content/add-event.md) to submit your event via Pull Request or GitHub Issue.


### PR DESCRIPTION
This PR addresses the Issue #73 — Event adding instructions should be more clear.

Previously, the steps to add an event were only present in content/add-event.md, which wasn’t linked with README.md so contributors could not find the instructions of how to add an event Now, contributors  can see those instructions and they can easily add their event. 

### Changes made
----------------------
- Added a new section **Adding Your Event** in [README.md](https://github.com/django/birthday20/blob/main/README.md)
<img width="1496" height="800" alt="Screenshot 2025-10-13 183206" src="https://github.com/user-attachments/assets/004b63d8-a864-4ec6-950c-a64631051d0c" />
