### PR TITLE
Issue 34:- Handle events without coordinates to avoid placing them at…

### DIFF
--- a/assets/js/events_map.js
+++ b/assets/js/events_map.js
@@ -27,6 +27,16 @@ function getColorByCategory(category) {
 let singleEventPopupLayer = null;
 
 function renderEvents(geojsonData, singleEventGeojsonData) {
+	// FIX: Remove events with missing/null coordinates
+	geojsonData.features = geojsonData.features.filter(f => {
+		return (
+			f.geometry &&
+			f.geometry.coordinates &&
+			f.geometry.coordinates.length === 2 &&
+			f.geometry.coordinates[0] !== null &&
+			f.geometry.coordinates[1] !== null
+		);
+	});
 	if (!geojsonData) {
 		return
 	}
@@ -82,6 +92,9 @@ function renderEvents(geojsonData, singleEventGeojsonData) {
 
 	const geojsonLayer = L.geoJSON(geojsonData, {
 		pointToLayer: (feature, latlng) => {
+			if (!feature.geometry || !feature.geometry.coordinates || feature.geometry.coordinates.includes(null)) {
+				return; // skip this feature entirely
+			}
 			const category = feature.properties.event_category;
 			const color = getColorByCategory(category);
 			const marker = L.circleMarker(latlng, {


### PR DESCRIPTION
Issue 34:- Handle events without coordinates to avoid placing them at the map center. #34

Events with missing or null coordinates were appearing at (0,0) on the map, creating incorrect markers in the ocean.

Solution:-
Filtered out events that have no valid latitude/longitude before rendering.
Added a backup check inside pointToLayer to skip any invalid feature.

✔ Result
Only events with real coordinates are displayed on the map, and invalid events are ignored, preventing wrong markers and wrong cluster behaviour.